### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete string escaping or encoding

### DIFF
--- a/src/cli/build-storybooks.ts
+++ b/src/cli/build-storybooks.ts
@@ -43,7 +43,7 @@ function deduplicateAssets(outputDir: string, targetSharedDir: string = sharedDi
   }
   // Patch HTML entry points to use /shared/ absolute paths
   const sharedDirNames = SHARED_DIRS.join('|');
-  const sharedFileNames = SHARED_FILES.map(f => f.replace(/\./g, '\\.')).join('|');
+  const sharedFileNames = SHARED_FILES.map(f => f.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
   const DIR_PATTERN = new RegExp(`(src|href)="(?:\\./)?((${sharedDirNames})/)`, 'g');
   const FILE_PATTERN = new RegExp(`(href)="(?:\\./)?((${sharedFileNames}))"`, 'g');
   for (const htmlFile of ['index.html', 'iframe.html']) {


### PR DESCRIPTION
Potential fix for [https://github.com/akshayjpatil/storybook-addon-semantic-version/security/code-scanning/4](https://github.com/akshayjpatil/storybook-addon-semantic-version/security/code-scanning/4)

In general, when interpolating literal strings into a `RegExp` constructor, all regex metacharacters in those strings must be escaped, not just selected ones like `.`. The robust approach is to run each file name through a function that escapes all regex special characters (including `\`) before joining them with `|` to form an alternation pattern.

The best fix here is to replace the custom `f.replace(/\./g, '\\.')` with a standard “escape for regex” transformation, applied to each `f` before joining. We can do this inline without adding new functions or changing behavior elsewhere. Specifically, update line 46 so that instead of only escaping `.`, it replaces any character that is special in regex syntax (`[ \ ^ $ . | ? * + ( ) ]`) with a backslash-prefixed version. This keeps existing behavior for the current file names and correctly handles future names that contain backslashes or other metacharacters. No new imports are needed; it uses built-in `String.prototype.replace` with a well-known pattern.

Concretely, in `src/cli/build-storybooks.ts`, change the definition of `sharedFileNames` on line 46 to:

- Use `.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')` on each file name instead of `.replace(/\./g, '\\.')`.

All other code (the construction of `FILE_PATTERN`, subsequent `replace` calls, and file operations) remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
