### PR TITLE
Potential fix for code scanning alert no. 6: Shell command built from environment values

### DIFF
--- a/src/cli/__tests__/build-storybooks.test.ts
+++ b/src/cli/__tests__/build-storybooks.test.ts
@@ -3,7 +3,18 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import semver from 'semver';
-import { copyDirIfNotExists, deduplicateAssets } from '../build-storybooks';
+import { copyDirIfNotExists, deduplicateAssets, getNpmCommand } from '../build-storybooks';
+
+describe('getNpmCommand', () => {
+  it('should use npm.cmd on Windows', () => {
+    expect(getNpmCommand('win32')).toBe('npm.cmd');
+  });
+
+  it('should use npm on non-Windows platforms', () => {
+    expect(getNpmCommand('linux')).toBe('npm');
+    expect(getNpmCommand('darwin')).toBe('npm');
+  });
+});
 
 describe('build-storybooks version sorting', () => {
   it('should sort versions newest-first with semver.rcompare', () => {

--- a/src/cli/build-storybooks.ts
+++ b/src/cli/build-storybooks.ts
@@ -10,6 +10,10 @@ const sharedDir = path.join(distDir, 'shared');
 const SHARED_DIRS = ['sb-manager', 'sb-addons', 'sb-preview', 'sb-common-assets'] as const;
 const SHARED_FILES = ['favicon.svg', 'favicon.ico'] as const;
 
+function getNpmCommand(platform: NodeJS.Platform = process.platform): string {
+  return platform === 'win32' ? 'npm.cmd' : 'npm';
+}
+
 function copyDirIfNotExists(src: string, dest: string): void {
   fs.mkdirSync(dest, { recursive: true });
   for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
@@ -74,9 +78,10 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   fs.mkdirSync(versionDir, { recursive: true });
   fs.mkdirSync(rootDir, { recursive: true });
   fs.mkdirSync(sharedDir, { recursive: true });
+  const npmCommand = getNpmCommand();
   // 1. Build the current version
   console.log(`Building version ${version}...`);
-  execFileSync('npm', ['run', 'build-storybook', '--', '-o', versionDir], {
+  execFileSync(npmCommand, ['run', 'build-storybook', '--', '-o', versionDir], {
     stdio: 'inherit',
   });
   deduplicateAssets(versionDir);
@@ -114,7 +119,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   // 4. Build root storybook
   console.log('Building root storybook...');
   execFileSync(
-    'npm',
+    npmCommand,
     ['run', 'build-storybook', '-c', '.storybook', '--', '-o', path.join(rootDir, 'storybook')],
     {
       stdio: 'inherit',
@@ -124,4 +129,4 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   console.log(':white_check_mark: All versions built.');
 }
 
-export { copyDirIfNotExists, deduplicateAssets };
+export { copyDirIfNotExists, deduplicateAssets, getNpmCommand };

--- a/src/cli/build-storybooks.ts
+++ b/src/cli/build-storybooks.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import semver from 'semver';
@@ -76,7 +76,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   fs.mkdirSync(sharedDir, { recursive: true });
   // 1. Build the current version
   console.log(`Building version ${version}...`);
-  execSync(`npm run build-storybook -- -o ${versionDir}`, {
+  execFileSync('npm', ['run', 'build-storybook', '--', '-o', versionDir], {
     stdio: 'inherit',
   });
   deduplicateAssets(versionDir);
@@ -113,11 +113,9 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
 
   // 4. Build root storybook
   console.log('Building root storybook...');
-  execSync(
-    `npm run build-storybook -c .storybook -- -o ${path.join(
-      rootDir,
-      'storybook'
-    )}`,
+  execFileSync(
+    'npm',
+    ['run', 'build-storybook', '-c', '.storybook', '--', '-o', path.join(rootDir, 'storybook')],
     {
       stdio: 'inherit',
     }


### PR DESCRIPTION
Potential fix for [https://github.com/akshayjpatil/storybook-addon-semantic-version/security/code-scanning/6](https://github.com/akshayjpatil/storybook-addon-semantic-version/security/code-scanning/6)

In general, to fix this kind of issue, avoid passing a single shell command string that embeds environment-derived values to `execSync`. Instead, call `execFileSync` (or `execSync` with `{ shell: false }`) and pass the base command and its arguments as separate array elements. This way, the dynamic path is not interpreted by a shell and is passed as a literal argument to the underlying process.

For this file, the problematic call is the one starting on line 116:

```ts
116:   execSync(
117:     `npm run build-storybook -c .storybook -- -o ${path.join(
118:       rootDir,
119:       'storybook'
120:     )}`,
121:     {
122:       stdio: 'inherit',
123:     }
124:   );
```

We should replace this with a safe invocation that does not use a shell. The simplest, behavior-preserving change is:

```ts
execSync('npm', ['run', 'build-storybook', '-c', '.storybook', '--', '-o', path.join(rootDir, 'storybook')], {
  stdio: 'inherit',
});
```

However, `execSync`’s signature in Node is `execSync(command[, options])`; it does not accept an arguments array. To provide arguments, we should switch to `execFileSync` from `child_process`, which has the signature `execFileSync(file[, args][, options])`. Therefore:

- Update the import on line 2 to import `execFileSync` instead of (or in addition to) `execSync`.
- Change both uses of `execSync` (lines 79 and 116) to `execFileSync` with argument arrays, eliminating template literals that embed paths in a shell string.

Concretely:

- On line 2, change `import { execSync } from 'child_process';` to `import { execFileSync } from 'child_process';`.
- On lines 78–81, replace:

  ```ts
  console.log(`Building version ${version}...`);
  execSync(`npm run build-storybook -- -o ${versionDir}`, {
    stdio: 'inherit',
  });
  ```

  with:

  ```ts
  console.log(`Building version ${version}...`);
  execFileSync('npm', ['run', 'build-storybook', '--', '-o', versionDir], {
    stdio: 'inherit',
  });
  ```

- On lines 115–123, replace the `execSync` call with:

  ```ts
  console.log('Building root storybook...');
  execFileSync(
    'npm',
    ['run', 'build-storybook', '-c', '.storybook', '--', '-o', path.join(rootDir, 'storybook')],
    {
      stdio: 'inherit',
    }
  );
  ```

This keeps the behavior (running the same npm script with the same arguments) while ensuring the paths are passed as literal arguments, not parsed by a shell.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
