### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/akshayjpatil/storybook-addon-semantic-version/security/code-scanning/1](https://github.com/akshayjpatil/storybook-addon-semantic-version/security/code-scanning/1)

In general, the fix is to explicitly define `permissions` for each job (or at the workflow root) to limit the `GITHUB_TOKEN` to the least privileges required. For a job that only needs to read the repository contents, `contents: read` is sufficient. Jobs that need to publish or modify the repository can request more specific write permissions.

In this workflow, the `publish` job already has `permissions: contents: write`, which is appropriate for creating releases and potentially updating tags. The `test` job, however, lacks a `permissions` block and should be restricted. The best fix without changing behavior is to add a `permissions` section to the `test` job setting `contents: read`. This is enough for `actions/checkout` and does not affect the `publish` job’s existing permissions. Concretely, in `.github/workflows/publish.yml`, under `jobs: test:`, insert:

```yaml
    permissions:
      contents: read
```

on its own indentation level, between `runs-on: ubuntu-latest` and `steps:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
